### PR TITLE
Update to tb-downloader.sh to check curl command

### DIFF
--- a/tb-downloader.sh
+++ b/tb-downloader.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Check if the 'curl' command is installed.
+if ! [ -x "$(command -v curl)" ]; then
+  echo 'Error: curl is not installed. Install curl and try again.' >&2
+  exit 1
+fi
+
 echo "Downloading openvpn config files..."
 if [ -f openvpn.zip ]
 then


### PR DESCRIPTION
If the user that runs this script does not have the CURL command installed, it produces an error but the rest of the script continues executing, inclusive shows the "Ready to install" message.

With this modification, first we check if the user has the CURL command installed.